### PR TITLE
Add dockerfile for Python agent

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ BASE_BUILD_TARGETS := $(TAG_SUFS:%=base.%)
 OAP_BUILD_TARGETS := $(TAG_SUFS:%=oap-server.%)
 COMPLEX_BUILD_TARGETS := $(BASE_BUILD_TARGETS) $(OAP_BUILD_TARGETS)
 COMPOSE_TARGETS := $(TAG_SUFS:%=compose.%)
-BUILD_TARGETS := $(COMPLEX_BUILD_TARGETS) ui java-agent
+BUILD_TARGETS := $(COMPLEX_BUILD_TARGETS) ui java-agent python-agent
 
 word-dot = $(word $2,$(subst ., ,$1))
 
@@ -50,6 +50,8 @@ ui:
 java-agent:
 	$(MAKE) -C java-agent build
 
+python-agent:
+	$(MAKE) -C python-agent build
 
 $(COMPOSE_TARGETS):
 	@echo "Booting $@"
@@ -67,6 +69,9 @@ push.ui:
 
 push.java-agent:
 	$(MAKE) -C java-agent push
+
+push.python-agent:
+	$(MAKE) -C python-agent push
 
 PUSH_TARGETS:=
 $(foreach TGT,$(BUILD_TARGETS),$(eval PUSH_TARGETS+=push.$(TGT)))

--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ This repository includes related files of following docker images:
  - OAP server
  - UI
  - Java agent
- 
+ - Python agent
+
  Documents of each version are in `v-x.y.z/oap` and `v-x.y.z/ui`. Such as [8.1.0 OAP](8/8.1.0/oap) and [8.1.0 UI](8/8.1.0/ui)
 
 The convenience images are published to Docker Hub and available from the `skywalking.docker.scarf.sh` endpoint.
@@ -19,8 +20,9 @@ The convenience images are published to Docker Hub and available from the `skywa
 - `skywalking.docker.scarf.sh/apache/skywalking-ui` ([Docker Hub](https://hub.docker.com/r/apache/skywalking-ui))
 - `skywalking.docker.scarf.sh/apache/skywalking-oap-server` ([Docker Hub](https://hub.docker.com/r/apache/skywalking-oap-server))
 
-Java agent images are available too.
+Java and Python agent images are available too.
 - `skywalking.docker.scarf.sh/apache/skywalking-java-agent` ([Docker Hub](https://hub.docker.com/r/apache/skywalking-java-agent))
+- `skywalking.docker.scarf.sh/apache/skywalking-python` ([Docker Hub](https://hub.docker.com/r/apache/skywalking-python))
 
 # How to build
 
@@ -31,18 +33,22 @@ From `8.4.0`, issuing follows to build relevant docker images
 ```sh
 # source 8/v8.4.0.sh if the target version is 8.4.0
 source <major_version>/v<version>.sh
+source python-agent/v<version>.sh
 
 make
 ```
 
 # How to publish images
 
-After a SkyWalking's Apache release, composing a new version environment setting script to `<major_version>` folder with the name like `v<version>.sh`
+After a SkyWalking's Apache release, composing a new version environment setting script to `<major_version>` folder with the name like `v<version>.sh`,
+the same goes for the Python agent, composing a new script naming `v<version>.sh` to `python-agent` folder.
 
 Building images as below:
 
 ```sh
 source <major_version>/v<version>.sh
+source python-agent/v<version>.sh
+
 make
 ```
 

--- a/python-agent/Dockerfile
+++ b/python-agent/Dockerfile
@@ -1,0 +1,25 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+ARG SW_PYTHON_VERSION
+
+FROM python:${SW_PYTHON_VERSION}
+
+ARG SW_PYTHON_PROTOCOL
+
+RUN pip install --no-cache-dir "apache-skywalking"[${SW_PYTHON_PROTOCOL}]
+
+ENTRYPOINT ["sw-python", "run"]

--- a/python-agent/Makefile
+++ b/python-agent/Makefile
@@ -1,0 +1,50 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+D := docker
+
+P := grpc http kafka
+
+TARGETS := py3.5 py3.6 py3.7 py3.8 py3.9
+
+py3.5: VERSION = 3.5
+py3.6: VERSION = 3.6
+py3.7: VERSION = 3.7
+py3.8: VERSION = 3.8
+py3.9: VERSION = 3.9
+
+PUSH_TARGETS := $(TARGETS:%=push-%)
+
+word-dash = $(word $2,$(subst -, ,$1))
+
+build: $(TARGETS)
+push: $(PUSH_TARGETS)
+
+$(TARGETS):
+	for p in $(P); do \
+		$(D) build $(SW_BUILD_ARGS) \
+				--build-arg SW_PYTHON_VERSION=$(VERSION) \
+				--build-arg SW_PTTHON_PROTOCOL=$$p \
+				-t apache/skywalking-python:${SW_PYTHON_AGENT_VERSION}-$$p-$@ \
+				. ; \
+	done
+
+
+$(PUSH_TARGETS):
+	$(eval version := $(call word-dash,$@,2))
+	for p in $(P); do \
+		$(D) push apache/skywalking-python:${SW_PYTHON_AGENT_VERSION}-$$p-${version}; \
+	done

--- a/python-agent/README.md
+++ b/python-agent/README.md
@@ -1,0 +1,38 @@
+# Apache SkyWalking Python Agent docker file
+
+**Docker images are not official ASF releases but provided for convenience. Recommended usage is always to build the
+source**
+
+<img src="http://skywalking.apache.org/assets/logo.svg" alt="SkyWalking logo" height="90px" align="right" />
+
+**SkyWalking**: an APM(application performance monitor) system, especially designed for microservices, cloud native and
+container-based (Docker, Kubernetes, Mesos) architectures.
+
+[![GitHub stars](https://img.shields.io/github/stars/apache/skywalking.svg?style=for-the-badge&label=Stars&logo=github)](https://github.com/apache/skywalking)
+[![Twitter Follow](https://img.shields.io/twitter/follow/asfskywalking.svg?style=for-the-badge&label=Follow&logo=twitter)](https://twitter.com/AsfSkyWalking)
+
+You could find the docker file [here](https://github.com/apache/skywalking-docker)
+
+This image hosts the SkyWalking Python agent package on top of official Python base images providing support from 
+Python 3.5 - 3.9.
+
+# How to use this image
+
+## Build your Python application image on top of this image
+
+```dockerfile
+FROM apache/skywalking-python:0.7.0-grpc-py3.9
+
+# ... build your Python application
+```
+
+You should start your Python application with `CMD`, 
+
+For example - `CMD ['gunicorn', 'app.wsgi']` 
+
+you don't need to care about enabling the SkyWalking Python agent manually, 
+it should be adopted and bootstrapped automatically through the `sw-python` CLI.
+
+# License
+
+[Apache 2.0 License.](/LICENSE)

--- a/python-agent/v0.7.0.sh
+++ b/python-agent/v0.7.0.sh
@@ -1,0 +1,17 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+export SW_PYTHON_AGENT_VERSION=0.7.0


### PR DESCRIPTION
This PR adds a Dockerfile and corresponding Makefile for building and releasing the Python agent images.

Closes https://github.com/apache/skywalking/issues/7461